### PR TITLE
OS Portability Support

### DIFF
--- a/src/commands/selectPullRequest.ts
+++ b/src/commands/selectPullRequest.ts
@@ -25,7 +25,7 @@ export async function selectPullRequest() {
         title: "Setting your environment",
         cancellable: false
     }, async (progress, _) => {
-        await execute({cmd: 'touch /tmp/empty'});
+        await fs.createFile('/tmp/empty');
 
         // progress.report({ increment: 0, message: "git fetch" });
         // await execute({cmd: 'git fetch'});


### PR DESCRIPTION
Using the already imported fs-extra module instead of an os-dependent shell child process.

This fixes #6 .
